### PR TITLE
Use constructor operation for ContentIndexEvent

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -445,8 +445,9 @@ dictionary ContentIndexEventInit : ExtendableEventInit {
   required DOMString id;
 };
 
-[Constructor(DOMString type, ContentIndexEventInit init), Exposed=ServiceWorker]
+[Exposed=ServiceWorker]
 interface ContentIndexEvent : ExtendableEvent {
+  constructor(DOMString type, ContentIndexEventInit init);
   readonly attribute DOMString id;
 };
 </script>


### PR DESCRIPTION
The Constructor extended attribute has been removed from Web IDL.